### PR TITLE
Update list-item.svelte

### DIFF
--- a/src/svelte/components/list-item.svelte
+++ b/src/svelte/components/list-item.svelte
@@ -264,6 +264,7 @@
   }
   function onChange(event) {
     dispatch('change', [event]);
+    if (radio || checkbox) checked = !checked;
     if (typeof $$props.onChange === 'function') $$props.onChange(event);
   }
   onMount(() => {


### PR DESCRIPTION
This fixes two-way binding of checkbox/radio list items for Svelte. Otherwise checkboxes do not reflect changes.